### PR TITLE
support for the smaller 7470A plotter

### DIFF
--- a/hp7475a_send.py
+++ b/hp7475a_send.py
@@ -151,7 +151,7 @@ def main():
             continue
 
         bufsz = plotter_cmd(tty, b'\033.B', True)
-        if bufsz < 256:
+        if bufsz < 192:
             print(f'Only {bufsz} bytes free. :-(', end='\r')
             sys.stdout.flush()
             time.sleep(0.25)


### PR DESCRIPTION
The 7470A plotter has only 255 bytes of buffer - so it doesnt start plotting at all